### PR TITLE
Read config from .carve/config.edn if one exist

### DIFF
--- a/carve.el
+++ b/carve.el
@@ -130,7 +130,7 @@
          (project-root (projectile-project-root))
          (has-config (file-exists-p (concat project-root ".carve/config.edn")))
          (carve-opts (if has-config
-                         (list "--opts")
+                         (list "--opts '{:merge-config true}'")
                        (list "--opts" "{:paths [\"src\" \"test\"] :report {:format :text}}"))))
     (carve--run-carve project-root carve-opts)))
 

--- a/carve.el
+++ b/carve.el
@@ -130,7 +130,7 @@
          (project-root (projectile-project-root))
          (has-config (file-exists-p (concat project-root ".carve/config.edn")))
          (carve-opts (if has-config
-                         (list "--opts '{:merge-config true}'")
+                         (list "--opts" "{:merge-config true}")
                        (list "--opts" "{:paths [\"src\" \"test\"] :report {:format :text}}"))))
     (carve--run-carve project-root carve-opts)))
 


### PR DESCRIPTION
Configs specified on the commandline (with `--opts`) cause the config file not to be read, unless :merge-config is specified.