### PR TITLE
Support loading using `(require 'carve)`

### DIFF
--- a/carve.el
+++ b/carve.el
@@ -170,4 +170,7 @@ Uses `carve-project-backend' to determine which backend to use."
 ;; - check for existence of src / test and use them if present
 ;; - key which will delete the form it refers to?
 
+
+(provide 'carve)
+
 ;;; carve.el ends here


### PR DESCRIPTION
When installing this module using e.g. Nix trivialBuild recipe, or presumably with straight.el, this final `(provide 'carve)` call is required. 

cf http://xahlee.info/emacs/emacs/elisp_feature_name.html